### PR TITLE
Criar schema sql para CRM de barbearia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog - TrimFlow CRM Database
+
+## [1.1] - 2024-01-13
+
+### 🔧 Correções
+- **CORRIGIDO**: Erro de ambiguidade na coluna `user_id` nas views
+  - Especificado `c.user_id` na view `user_stats`
+  - Melhorado JOIN na view `upcoming_appointments` para incluir validação de `user_id`
+  - Adicionado `AND a.user_id = c.user_id` nos JOINs para maior segurança
+
+### 📝 Melhorias
+- **ADICIONADO**: Documentação sobre troubleshooting no README
+- **MELHORADO**: JOINs nas views agora validam que appointments e clients pertencem ao mesmo usuário
+
+### 🐛 Problemas Resolvidos
+- Erro SQL: `column reference "user_id" is ambiguous` na linha 176
+
+---
+
+## [1.0] - 2024-01-13
+
+### 🎉 Lançamento Inicial
+- **CRIADO**: Script SQL completo para TrimFlow CRM
+- **CRIADO**: Tabela `clients` com todos os campos solicitados
+- **CRIADO**: Tabela `appointments` com relacionamentos
+- **IMPLEMENTADO**: Row Level Security (RLS) completo
+- **ADICIONADO**: Triggers automáticos para timestamps
+- **CRIADO**: Views úteis para consultas comuns
+- **DOCUMENTADO**: README completo com instruções

--- a/README_TrimFlow_Database.md
+++ b/README_TrimFlow_Database.md
@@ -103,6 +103,8 @@ Fornece estatísticas básicas para cada barbeiro:
 SELECT * FROM user_stats WHERE user_id = 'seu_user_id';
 ```
 
+> **Nota**: As views foram corrigidas para evitar ambiguidade de colunas `user_id` nos JOINs entre tabelas.
+
 ## 💡 Exemplos de Uso
 
 ### Inserir um Cliente
@@ -164,6 +166,10 @@ COPY (SELECT * FROM appointments WHERE user_id = 'seu_user_id') TO 'appointments
 ```
 
 ## 🆘 Troubleshooting
+
+### Erro de Ambiguidade de Coluna
+**Erro**: `column reference "user_id" is ambiguous`
+**Solução**: Este erro foi corrigido na versão atual do script. Se ainda ocorrer, certifique-se de usar a versão mais recente do `trimflow_database_setup.sql`.
 
 ### Erro de Permissão
 Se você receber erros de permissão, verifique se:

--- a/trimflow_database_setup.sql
+++ b/trimflow_database_setup.sql
@@ -166,21 +166,21 @@ SELECT
     c.email as client_email,
     c.notes as client_notes
 FROM appointments a
-JOIN clients c ON a.client_id = c.id
+JOIN clients c ON a.client_id = c.id AND a.user_id = c.user_id
 WHERE a.date >= CURRENT_DATE
 ORDER BY a.date, a.time;
 
 -- View para estatísticas do barbeiro
 CREATE VIEW user_stats AS
 SELECT 
-    user_id,
+    c.user_id,
     COUNT(DISTINCT c.id) as total_clients,
     COUNT(a.id) as total_appointments,
     COUNT(CASE WHEN a.date >= CURRENT_DATE THEN 1 END) as upcoming_appointments,
     MAX(a.date) as last_appointment_date
 FROM clients c
-LEFT JOIN appointments a ON c.id = a.client_id
-GROUP BY user_id;
+LEFT JOIN appointments a ON c.id = a.client_id AND c.user_id = a.user_id
+GROUP BY c.user_id;
 
 -- ============================================================================
 -- INSERÇÃO DE DADOS EXEMPLO (opcional - remover em produção)


### PR DESCRIPTION
Fix ambiguous `user_id` column reference in SQL views to enable successful Supabase database setup.

The original script failed to execute in Supabase with an `ERROR: 42702: column reference "user_id" is ambiguous`. This occurred because the `user_id` column was present in both `clients` and `appointments` tables, and the `user_stats` and `upcoming_appointments` views did not explicitly qualify which table's `user_id` to use in `SELECT` and `GROUP BY` clauses, and also required `user_id` matching in JOIN conditions for proper RLS integration.